### PR TITLE
add GCS logging functionality

### DIFF
--- a/src/config/GCSLog.js
+++ b/src/config/GCSLog.js
@@ -1,0 +1,44 @@
+/* eslint-disable camelcase */
+class GCSLog {
+  /**
+   * GCSLog Methods
+   */
+  readLogs(service_id, version) {
+    return this.request({
+      method: 'GET',
+      url: `/service/${service_id}/version/${version}/logging/gcs`,
+    });
+  }
+
+  readLog(service_id, version, name) {
+    return this.request({
+      method: 'GET',
+      url: `/service/${service_id}/version/${version}/logging/gcs/${name}`,
+    });
+  }
+
+  createLog(service_id, version, data) {
+    return this.request({
+      method: 'POST',
+      url: `/service/${service_id}/version/${version}/logging/gcs`,
+      data,
+    });
+  }
+
+  updateLog(service_id, version, old_name, data) {
+    return this.request({
+      method: 'PUT',
+      url: `/service/${service_id}/version/${version}/logging/gcs/${old_name}`,
+      data,
+    });
+  }
+
+  deleteLog(service_id, version, name) {
+    return this.request({
+      method: 'DELETE',
+      url: `/service/${service_id}/version/${version}/logging/gcs/${name}`,
+    });
+  }
+}
+
+module.exports = GCSLog;

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ const Dictionary = require('./config/Dictionary');
 const DictionaryInfo = require('./config/DictionaryInfo');
 const DictionaryItem = require('./config/DictionaryItem');
 const Domain = require('./config/Domain');
+const GCSLog = require('./config/GCSLog');
 const Service = require('./config/Service');
 const Settings = require('./config/Settings');
 const VCL = require('./config/VCL');
@@ -25,6 +26,7 @@ class Fastly extends Many(
   DictionaryInfo,
   DictionaryItem,
   Domain,
+  GCSLog,
   Service,
   Settings,
   VCL,


### PR DESCRIPTION
TODO: abstract logging functionality entirely. Looks like most of the logging endpoints follow the same process and it's just a matter of `/service/${service_id}/version/${version}/logging/${provider}/`.