### PR TITLE
update VCL class to include a 'set main' feature

### DIFF
--- a/src/config/VCL.js
+++ b/src/config/VCL.js
@@ -46,6 +46,13 @@ class VCL {
       url: `/service/${service_id}/version/${version}/vcl/${name}`,
     });
   }
+
+  setMainVcl(service_id, version, name) {
+    return this.request({
+      method: 'PUT',
+      url: `/service/${service_id}/version/${version}/vcl/${name}/main`,
+    });
+  }
 }
 
 module.exports = VCL;


### PR DESCRIPTION
When uploading an entire boilerplate VCL, there needs to be a way to set it as the main VCL.